### PR TITLE
Found more places in the application where the resolution was defined

### DIFF
--- a/android/app/src/main/java/org/jitsi/meet/MainActivity.java
+++ b/android/app/src/main/java/org/jitsi/meet/MainActivity.java
@@ -153,7 +153,7 @@ public class MainActivity extends JitsiMeetActivity {
             .setWelcomePageEnabled(true)
             .setServerURL(buildURL(defaultURL))
             .setFeatureFlag("call-integration.enabled", false)
-            .setFeatureFlag("resolution", 360)
+            .setFeatureFlag("resolution", 1080)
             .setFeatureFlag("server-url-change.enabled", !configurationByRestrictions)
             .build();
         JitsiMeet.setDefaultConferenceOptions(defaultOptions);

--- a/react/features/video-quality/reducer.js
+++ b/react/features/video-quality/reducer.js
@@ -12,8 +12,8 @@ const DEFAULT_STATE = {
     preferredVideoQuality: VIDEO_QUALITY_LEVELS.ULTRA
 };
 
-DEFAULT_STATE.minHeightForQualityLvl.set(360, VIDEO_QUALITY_LEVELS.STANDARD);
-DEFAULT_STATE.minHeightForQualityLvl.set(720, VIDEO_QUALITY_LEVELS.HIGH);
+DEFAULT_STATE.minHeightForQualityLvl.set(1080, VIDEO_QUALITY_LEVELS.STANDARD);
+DEFAULT_STATE.minHeightForQualityLvl.set(1200, VIDEO_QUALITY_LEVELS.HIGH);
 
 
 // When the persisted state is initialized the current state (for example the default state) is erased.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a thorough description below.

Contributors guide: https://github.com/jitsi/jitsi-meet/blob/master/CONTRIBUTING.md
-->
