### PR TITLE
Disabling invites from within the meeting

### DIFF
--- a/config.js
+++ b/config.js
@@ -531,7 +531,7 @@ var config = {
        'fullscreen',
        'hangup',
     //    'help',
-       'invite',
+    //   'invite',
     //    'livestreaming',
        'microphone',
        'mute-everyone',
@@ -865,7 +865,7 @@ var config = {
     // Mainly privacy related settings
 
     // Disables all invite functions from the app (share, invite, dial out...etc)
-    // disableInviteFunctions: true,
+    disableInviteFunctions: true,
 
     // Disables storing the room name to the recents list
     // doNotStoreRoom: true,


### PR DESCRIPTION
Users need to invite uses meet.intulse.com.
