### PR TITLE
Fixed z-index for lobby knocking participant list

### DIFF
--- a/css/premeeting/_lobby.scss
+++ b/css/premeeting/_lobby.scss
@@ -52,7 +52,7 @@
     overflow-y: auto;
     position: fixed;
     top: 30px;
-    z-index: $toolbarZ + 1;
+    z-index: $sideToolbarContainerZ + 1;
 
     &:empty {
         border: none;


### PR DESCRIPTION
Changed the z-index for the knocking participant list so that it appears above the chat sidebar.